### PR TITLE
Speedup in AlbTextEditorLineSegmentPieceMap

### DIFF
--- a/src/Album/AlbTextEditorLineSegmentPieceMap.class.st
+++ b/src/Album/AlbTextEditorLineSegmentPieceMap.class.st
@@ -42,20 +42,18 @@ AlbTextEditorLineSegmentPieceMap >> initialize [
 
 { #category : #accessing }
 AlbTextEditorLineSegmentPieceMap >> pieceForElement: aBlElement ifAbsent: anAbsentBlock [
-	<return: #AlbTextEditorAbstractSegmentPiece or: #Object>
-	map associations do: [ :eachAssociation |
-		(eachAssociation value includes: aBlElement) 
-			ifTrue: [ ^ eachAssociation key ] ].
 
-	^ anAbsentBlock value
+	^ self
+		  pieceForElement: aBlElement
+		  ifPresent: [ :aPiece | ^ aPiece ]
+		  ifAbsent: anAbsentBlock
 ]
 
 { #category : #accessing }
 AlbTextEditorLineSegmentPieceMap >> pieceForElement: aBlElement ifPresent: aBlock ifAbsent: anAbsentBlock [
-	<return: #AlbTextEditorAbstractSegmentPiece or: #Object>
-	map associations do: [ :eachAssociation |
-		(eachAssociation value includes: aBlElement) 
-			ifTrue: [ ^ aBlock value: eachAssociation key ] ].
+
+	map keysAndValuesDo: [ :k :v |
+		(v includes: aBlElement) ifTrue: [ ^ aBlock value: k ] ].
 
 	^ anAbsentBlock value
 ]


### PR DESCRIPTION
This optimizes a bit dragging the scroll bar.

See: #34 

In my informal profile measurements, I saw a 2x speedup in `selectionRectangles` , still slow.
I enclosed this calculation in a `[ ] timeToRun` and log shows between 5ms and 12ms on each execution. Probably we can achieve 0ms by caching. Still understanding what's the motivation of this `selectionRectangles`. Solutions may be caching the result, or count with the inverted Dictionary that it now problematic (one where we search over the keys of it, not the values). 

Maybe @plantec has an idea