### PR TITLE
Renamed senders of #size: to #extent:

### DIFF
--- a/src/Album-Examples/AlbEditorTextFlowLayoutExamples.class.st
+++ b/src/Album-Examples/AlbEditorTextFlowLayoutExamples.class.st
@@ -16,7 +16,7 @@ AlbEditorTextFlowLayoutExamples >> container [
 			c vertical fitContent ];
 		addChildren: (20 timesCollect: [
 			BlElement new
-				size: 75@30;
+				extent: 75@30;
 				margin: (BlInsets all: 4);
 				background: (Color random alpha: 0.5) ]).
 			

--- a/src/Album-Examples/AlbExamplesSeeClassSide.class.st
+++ b/src/Album-Examples/AlbExamplesSeeClassSide.class.st
@@ -365,10 +365,10 @@ broken in GlamorousToolKit but what to do with that ?
 		stencil: [  {  
 			BlElement new
 				background: (Color gray alpha: 0.4);
-				size: 20@100.
+				extent: 20@100.
 			BlElement new
 				background: (Color red alpha: 0.4);
-				size: 20@10. } ].
+				extent: 20@10. } ].
 
 	text := 'Hello >' asRopedText attribute: attribute.
 	ed := AlbEditorElement new "dresser: AlbTextAreaDresser new".
@@ -436,7 +436,7 @@ AlbExamplesSeeClassSide class >> example_EditorWithReplacingAdornment [
 	aText := ('Hello' , String cr , 'World') asRopedText fontSize: 20.
 	(aText from: 4 to: 4) replacingAdornment: [
 		BlElement new
-			size: 20 @ 6;
+			extent: 20 @ 6;
 			background: Color red ].
 	ed := aText onAlbum.
 	ed withRowNumbers.

--- a/src/Album-Examples/AlbTextEditorByScripterExamples.class.st
+++ b/src/Album-Examples/AlbTextEditorByScripterExamples.class.st
@@ -93,7 +93,7 @@ AlbTextEditorByScripterExamples class >> textWithAdornment [
 	^ 'Hello world
 Next line with ' asRopedText, ('adornment' asRopedText appendingAdornment: [
 	BlElement new
-		size: 200@100;
+		extent: 200@100;
 		background: (Color gray alpha: 0.2);
 		id: #adornment ]), ' element' asRopedText
 ]

--- a/src/Album-Examples/AlbTextEditorExamples.class.st
+++ b/src/Album-Examples/AlbTextEditorExamples.class.st
@@ -64,7 +64,7 @@ AlbTextEditorExamples class >> editorWithAdormentDynamicAttribute [
 			AlbTextAdornmentDynamicAttribute new 
 				stencil: [ 
 					BlElement new 
-						size: 70 @ 50; 
+						extent: 70 @ 50; 
 						margin: (BlInsets all: 5);
 						background: Color red ] }
 		from: 1
@@ -98,11 +98,11 @@ AlbTextEditorExamples class >> editorWithAdormentDynamicAttributeReturningTwoEle
 			AlbTextAdornmentDynamicAttribute new 
 				stencil: [ 
 					{ BlElement new 
-						size: 70 @ 50; 
+						extent: 70 @ 50; 
 						margin: (BlInsets all: 5);
 						background: Color red.
 					BlElement new 
-						size: 70 @ 50; 
+						extent: 70 @ 50; 
 						margin: (BlInsets all: 5);
 						background: Color green } ] }
 		from: 1
@@ -236,15 +236,24 @@ AlbTextEditorExamples class >> exampleMethodTextOpen [
 { #category : #examples }
 AlbTextEditorExamples class >> exampleMethodTextOpenEmbedElement [
 	<script>
-	| space editorElement |
 
+	| space editorElement |
 	editorElement := self elementWithMethod.
-	editorElement editor text attributes: {
-		BlFontSizeAttribute size: 18.
-	}.
-	editorElement editor text attributes: {
-		AlbTextAdornmentDynamicAttribute new stencil: [ BlElement new size: 70 @ 50; background: Color red; yourself ]
-	} from: 30 to: 30.
+
+	editorElement editor text
+		attributes: { BlFontSizeAttribute size: 18 }.
+
+	editorElement editor text
+		attributes: {
+			AlbTextAdornmentDynamicAttribute new
+				stencil: [
+					BlElement new
+						extent: 70 @ 50;
+						background: Color red;
+						yourself ];
+				yourself
+		} from: 30 to: 30.
+
 	editorElement constraintsDo: [ :c |
 		c horizontal matchParent.
 		c vertical matchParent ].
@@ -360,7 +369,7 @@ AlbTextEditorExamples class >> newBeReplaceTextAttribute [
 	^ AlbTextAdornmentDynamicAttribute new
 		beReplace;
 		stencil: [ BlElement new 
-			size: 10@10; 
+			extent: 10@10; 
 			background: Color lightGray ]
 ]
 
@@ -386,7 +395,7 @@ AlbTextEditorExamples class >> newElement [
 AlbTextEditorExamples class >> newMethodText [
 	<gtExample>
 	
-	^ (AlbTextEditorExamples class >> #fullDrawOn:) sourceCode asRopedText
+	^ (Integer >> #bitAnd:) sourceCode asRopedText
 ]
 
 { #category : #'instance creation' }

--- a/src/Album-Examples/AlbTextEditorReplacingAdornmentsExamples.class.st
+++ b/src/Album-Examples/AlbTextEditorReplacingAdornmentsExamples.class.st
@@ -34,13 +34,13 @@ AlbTextEditorReplacingAdornmentsExamples class >> singleLineTextWithMultipleOver
 		replacingAdornment: [
 			BlElement new
 				geometry: BlEllipseGeometry new;
-				size: 20@20;
+				extent: 20@20;
 				background: Color blue ].
 	(aText from: 5 to: 9)
 		replacingAdornment: [
 			BlElement new
 				geometry: BlEllipseGeometry new;
-				size: 20@20;
+				extent: 20@20;
 				background: Color red ].
 
 	^ (AlbEditorElement new text: aText) openInOBlSpace 
@@ -57,12 +57,12 @@ AlbTextEditorReplacingAdornmentsExamples class >> singleLineTextWithMultipleRepl
 		replacingAdornment: [
 			BlElement new
 				geometry: BlEllipseGeometry new;
-				size: 20@20;
+				extent: 20@20;
 				background: Color red ];
 		replacingAdornment: [
 			BlElement new
 				geometry: BlEllipseGeometry new;
-				size: 20@20;
+				extent: 20@20;
 				background: Color blue ].
 
 	^ aText onAlbum openInOBlSpace 
@@ -78,7 +78,7 @@ AlbTextEditorReplacingAdornmentsExamples class >> singleLineTextWithReplacementA
 		replacingAdornment: [
 			BlElement new
 				geometry: BlEllipseGeometry new;
-				size: 20@20;
+				extent: 20@20;
 				background: Color gray ].
 
 	^ aText onAlbum openInOBlSpace 
@@ -95,7 +95,7 @@ AlbTextEditorReplacingAdornmentsExamples class >> singleLineTextWithReplacementF
 		replacingAdornment: [
 			BlElement new
 				geometry: BlEllipseGeometry new;
-				size: 20@20;
+				extent: 20@20;
 				background: Color blue ].
 			
 	^ aText onAlbum openInOBlSpace 
@@ -112,7 +112,7 @@ AlbTextEditorReplacingAdornmentsExamples class >> singleLineTextWithReplacementL
 		replacingAdornment: [
 			BlElement new
 				geometry: BlEllipseGeometry new;
-				size: 20@20;
+				extent: 20@20;
 				background: Color gray ].
 			
 	^ aText onAlbum openInOBlSpace 
@@ -129,7 +129,7 @@ AlbTextEditorReplacingAdornmentsExamples class >> singleLineTextWithReplacementM
 		replacingAdornment: [
 			BlElement new
 				geometry: BlEllipseGeometry new;
-				size: 20@20;
+				extent: 20@20;
 				background: Color red ].
 
 	^ aText onAlbum openInOBlSpace 

--- a/src/Album-Tests/AlbTextEditorLineSegmentTest.class.st
+++ b/src/Album-Tests/AlbTextEditorLineSegmentTest.class.st
@@ -807,7 +807,7 @@ AlbTextEditorLineSegmentTest >> test_emptyEditor [
 		equals: (0 to: 0).
 
 	aTextEditorElement := AlbEditorElement new.
-	aTextEditorElement size: 600 @ 600.
+	aTextEditorElement extent: 600 @ 600.
 	aTextEditorElement editor: aTextEditor.
 	aTextEditorElement forceLayout.
 
@@ -2522,7 +2522,7 @@ AlbTextEditorLineSegmentTest >> text_HelloCrWorldCr_WithAppendingAfterWorld [
 
 	aText := ('Hello', String cr, 'World', String cr) asRopedText fontSize: 20.
 	(aText from: 7 to: 11)
-		appendingAdornment: [ BlElement new size: 6@6; background: Color red ].
+		appendingAdornment: [ BlElement new extent: 6@6; background: Color red ].
 		
 	^ aText
 ]
@@ -2534,7 +2534,7 @@ AlbTextEditorLineSegmentTest >> text_HelloCrWorldCr_WithReplacementOfWorld [
 
 	aText := ('Hello', String cr, 'World', String cr) asRopedText fontSize: 20.
 	(aText from: 7 to: 11)
-		replacingAdornment: [ BlElement new size: 6@6; background: Color red ].
+		replacingAdornment: [ BlElement new extent: 6@6; background: Color red ].
 		
 	^ aText
 ]
@@ -2546,7 +2546,7 @@ AlbTextEditorLineSegmentTest >> text_HelloCrWorld_WithReplacementAndAppendingOfW
 
 	aText := self text_HelloCrWorld_WithReplacementOfWorld.
 	(aText from: 7 to: 11)
-		appendingAdornment: [ BlElement new size: 6@6; background: Color blue ].
+		appendingAdornment: [ BlElement new extent: 6@6; background: Color blue ].
 		
 	^ aText
 ]
@@ -2558,7 +2558,7 @@ AlbTextEditorLineSegmentTest >> text_HelloCrWorld_WithReplacementOfWorld [
 
 	aText := ('Hello', String cr, 'World') asRopedText fontSize: 20.
 	(aText from: 7 to: 11)
-		replacingAdornment: [ BlElement new size: 6@6; background: Color red ].
+		replacingAdornment: [ BlElement new extent: 6@6; background: Color red ].
 		
 	^ aText
 ]
@@ -2570,7 +2570,7 @@ AlbTextEditorLineSegmentTest >> text_HelloSpaceWorld_WithReplacementOfSpace [
 
 	aText := ('Hello World') asRopedText fontSize: 20.
 	(aText from: 6 to: 6)
-		replacingAdornment: [ BlElement new size: 6@6; background: Color red ].
+		replacingAdornment: [ BlElement new extent: 6@6; background: Color red ].
 		
 	^ aText
 ]
@@ -2591,7 +2591,7 @@ AlbTextEditorLineSegmentTest >> text_Hello_1_WithAppending [
 
 	aText appendingAdornment: [
 		BlElement new
-			size: 20@20;
+			extent: 20@20;
 			background: (Color gray alpha: 0.5);
 			geometry: BlEllipseGeometry new ].
 
@@ -2614,7 +2614,7 @@ AlbTextEditorLineSegmentTest >> text_Hello_Smart_World_WithAppending [
 		bold;
 		appendingAdornment: [
 			BlElement new
-				size: 16@16;
+				extent: 16@16;
 				background: (Color black alpha: 0.5);
 				geometry: BlEllipseGeometry new ].
 	
@@ -2623,7 +2623,7 @@ AlbTextEditorLineSegmentTest >> text_Hello_Smart_World_WithAppending [
 		bold;
 		appendingAdornment: [
 			BlElement new
-				size: 16@16;
+				extent: 16@16;
 				background: (Color gray alpha: 0.5);
 				geometry: BlEllipseGeometry new ].
 
@@ -2632,7 +2632,7 @@ AlbTextEditorLineSegmentTest >> text_Hello_Smart_World_WithAppending [
 		bold;
 		appendingAdornment: [
 			BlElement new
-				size: 16@16;
+				extent: 16@16;
 				background: (Color lightGray alpha: 0.5);
 				geometry: BlEllipseGeometry new ].
 
@@ -2653,7 +2653,7 @@ AlbTextEditorLineSegmentTest >> text_Hello_World_Cr_WithReplacement [
 
 	aText := ('Hello', String cr, String cr, 'World', String cr) asRopedText fontSize: 20.
 	(aText from: 8 to: 12)
-		replacingAdornment: [ BlElement new size: 6@6; background: Color red ].
+		replacingAdornment: [ BlElement new extent: 6@6; background: Color red ].
 		
 	^ aText
 ]
@@ -2665,7 +2665,7 @@ AlbTextEditorLineSegmentTest >> text_Hello_World_WithReplacementAndAppendingOfLi
 
 	aText := self text_Hello_World_WithReplacementOfLineBreak.
 	(aText from: 4 to: 8)
-		appendingAdornment: [ BlElement new size: 6@6; background: Color blue ].	
+		appendingAdornment: [ BlElement new extent: 6@6; background: Color blue ].	
 	
 	^ aText
 ]
@@ -2677,7 +2677,7 @@ AlbTextEditorLineSegmentTest >> text_Hello_World_WithReplacementOfLineBreak [
 
 	aText := ('Hello', String cr, 'World') asRopedText fontSize: 20.
 	(aText from: 4 to: 8)
-		replacingAdornment: [ BlElement new size: 6@6; background: Color red ].
+		replacingAdornment: [ BlElement new extent: 6@6; background: Color red ].
 		
 	^ aText
 ]

--- a/src/Album-Tests/AlbTextEditorLineSplitterTest.class.st
+++ b/src/Album-Tests/AlbTextEditorLineSplitterTest.class.st
@@ -10,7 +10,7 @@ AlbTextEditorLineSplitterTest >> beReplaceTextAttribute [
 	^ AlbTextAdornmentDynamicAttribute new
 		beReplace;
 		stencil: [ BlElement new 
-			size: 10@10; 
+			extent: 10@10; 
 			background: Color lightGray ]
 ]
 
@@ -29,10 +29,10 @@ AlbTextEditorLineSplitterTest >> beReplaceTextAttributeReturningTwoElements [
 		beReplace;
 		stencil: [ 
 			{ BlElement new 
-				size: 10@10; 
+				extent: 10@10; 
 				background: Color lightGray.
 			 BlElement new 
-				size: 10@10; 
+				extent: 10@10; 
 				background: Color gray } ]
 ]
 
@@ -455,7 +455,7 @@ AlbTextEditorLineSplitterTest >> test_split_HelloSpaceWorldWithReplacementOfSpac
 	| aText aSplitter aStream |
 
 	aText := ('Hello World') asRopedText.
-	(aText from: 5 to: 7) replacingAdornment: [ BlElement new size: 6@6; background: Color red ].
+	(aText from: 5 to: 7) replacingAdornment: [ BlElement new extent: 6@6; background: Color red ].
 
 	aSplitter := self textLineSplitter.
 	aStream := self textSegmentStream.

--- a/src/Album/AlbOppositeDelimiterUpdater.class.st
+++ b/src/Album/AlbOppositeDelimiterUpdater.class.st
@@ -21,7 +21,7 @@ AlbOppositeDelimiterUpdater >> closeOppositeDelimiter: oppositeTextElement at: l
 		        (1 @ 2 corner: 0 @ 2).
 	^ AlbOppositeDelimiterElement new
 		  position: bnds origin;
-		  size: bnds extent
+		  extent: bnds extent
 ]
 
 { #category : #'opposite delimiter' }
@@ -96,7 +96,7 @@ AlbOppositeDelimiterUpdater >> openOppositeDelimiter: oppositeTextElement at: lo
 		        (1 @ 2 corner: 0 @ 2).
 	^ AlbOppositeDelimiterElement new
 		  position: bnds origin;
-		  size: bnds extent
+		  extent: bnds extent
 ]
 
 { #category : #'event handling' }

--- a/src/Album/AlbTextEmbellishmentAttribute.class.st
+++ b/src/Album/AlbTextEmbellishmentAttribute.class.st
@@ -24,7 +24,7 @@ AlbTextEmbellishmentAttribute >> doAffect: aTTextEditorTextualPiece in: anEditor
 	
 	^ {
 		aReplacementTextElement.
-		BlElement new size: 0@0
+		BlElement new extent: 0@0
 	}
 ]
 

--- a/src/Album/AlbTextReplacingAttribute.class.st
+++ b/src/Album/AlbTextReplacingAttribute.class.st
@@ -34,7 +34,7 @@ AlbTextReplacingAttribute >> doAffect: aTTextEditorTextualPiece in: anEditorElem
 	
 	^ {
 		aReplacementTextElement.
-		BlElement new size: 0@0
+		BlElement new extent: 0@0
 	}
 ]
 


### PR DESCRIPTION
See: https://github.com/pharo-graphics/Bloc/issues/802

Manually picked these changes one by one, using the following scope:

ourPackages := PackageOrganizer default packages
		  select: [ :package | package name beginsWithAnyOf: #(Bloc Toplo Album) ].
scope := ScopesManager newScopeFrom: ourPackages.
scope label: 'Bloc ecosystem'.
ScopesManager addScope: scope.