### PR TITLE
AlbTextEditorHistory: tolerate text that was replaced

### DIFF
--- a/src/Album-Tests/AlbTextEditorHistoryTest.class.st
+++ b/src/Album-Tests/AlbTextEditorHistoryTest.class.st
@@ -108,3 +108,22 @@ AlbTextEditorHistoryTest >> test_insert_select_remove_and_undo_then_redo3 [
 	self assert: editor privateText asString equals: 'X'.
 	^ editorElement
 ]
+
+{ #category : #tests }
+AlbTextEditorHistoryTest >> test_replace_text_from_inserted_event [
+
+	| editorElement editor |
+	editorElement := '' asRopedText onAlbum.
+	editor := editorElement editor.
+	editor addEventHandler: (BlEventHandler
+		on: AlbTextInsertedEvent
+		do: [ :evt |
+			editorElement text: (String new: evt text size withAll: $*) asRopedText ]).
+
+	editor inserter
+		at: 0;
+		string: 'A';
+		insert.
+
+	self assert: editor privateText asString equals: '*'
+]

--- a/src/Album/AlbTextEditorHistory.class.st
+++ b/src/Album/AlbTextEditorHistory.class.st
@@ -62,11 +62,11 @@ AlbTextEditorHistory >> groupDuring: aBlock [
 		shouldGroup := wasGrouped.
 		shouldGroup ifFalse: [
 			currentGroup commands
-				ifEmpty: [ undoCommands remove: currentGroup ]
+				ifEmpty: [ undoCommands remove: currentGroup ifAbsent: [ ] ]
 				ifNotEmpty: [ :theCommands |
 					theCommands size = 1
 						ifTrue: [
-							undoCommands remove: currentGroup.
+							undoCommands remove: currentGroup ifAbsent: [ ].
 							undoCommands addAll: theCommands ] ] ] ]
 ]
 


### PR DESCRIPTION
Includes a test.
Fixes https://github.com/pharo-graphics/Toplo/issues/221